### PR TITLE
Link line wrapping fix

### DIFF
--- a/_sass/partials/_base.scss
+++ b/_sass/partials/_base.scss
@@ -107,7 +107,6 @@ h3 {
  */
 a {
   @include link-variant($link-color, $link-hover-color);
-  display: inline-block;
   text-decoration: none;
   transition: color .5s;
   position: relative;


### PR DESCRIPTION
Fix obnoxious line breaks in narrow windows/on mobile caused by inline-block property on links